### PR TITLE
Improvement/18 gun rotation trigger

### DIFF
--- a/Assets/Scenes/hands shooting mech test.unity
+++ b/Assets/Scenes/hands shooting mech test.unity
@@ -778,14 +778,11 @@ MonoBehaviour:
   previousXRotation: 0
   currentXRotation: 0
   changeInXRotation: 0
-  updateTransformsEveryNFrame: 0
-  frames: 0
   gunController: {fileID: 1205415066}
   minChangeToShootGun: 12
   maxChangeToShoot: 25
-  inFramesBetweenShot: 30
+  inFramesBetweenShot: 45
   framesSinceLastShot: -1
-  hasShotGunThisInterval: 0
 --- !u!1 &1636623401
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/hands shooting mech test.unity
+++ b/Assets/Scenes/hands shooting mech test.unity
@@ -465,6 +465,26 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 481164, guid: ce816f2e6abb0504092c23ed9b970dfd, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 481164, guid: ce816f2e6abb0504092c23ed9b970dfd, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 481164, guid: ce816f2e6abb0504092c23ed9b970dfd, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 481164, guid: ce816f2e6abb0504092c23ed9b970dfd, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 481164, guid: ce816f2e6abb0504092c23ed9b970dfd, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 11400010, guid: ce816f2e6abb0504092c23ed9b970dfd, type: 3}
       propertyPath: m_Enabled
       value: 0
@@ -730,7 +750,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 994951227}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: b8d72c6dfc19f064c86418f85b5135ec, type: 3}
   m_Name: 
@@ -742,6 +762,30 @@ MonoBehaviour:
   gunController: {fileID: 1205415066}
   inFramesBetweenShot: 30
   framesSinceLastShot: -1
+--- !u!114 &1618116325
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 994951227}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4672db08c1e9ae47b8c15ffcb1ad013, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  updatePreviousPositionInterval: 0.5
+  previousXRotation: 0
+  currentXRotation: 0
+  changeInXRotation: 0
+  updateTransformsEveryNFrame: 0
+  frames: 0
+  gunController: {fileID: 1205415066}
+  minChangeToShootGun: 12
+  maxChangeToShoot: 25
+  inFramesBetweenShot: 30
+  framesSinceLastShot: -1
+  hasShotGunThisInterval: 0
 --- !u!1 &1636623401
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/AngleBasedShootTrigger.cs
+++ b/Assets/Scripts/AngleBasedShootTrigger.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class AngleBasedShootTrigger : MonoBehaviour
 {
     [Header("Rotations")]
-    public float updatePreviousPositionInterval = 0.5f;
+    public float updatePreviousPositionInterval = 0.3f;
     public float previousXRotation;
     public float currentXRotation;
     public float changeInXRotation;
@@ -39,19 +39,23 @@ public class AngleBasedShootTrigger : MonoBehaviour
 
     void UpdatePreviousForwardPosition()
     {
-        gunPrevPosition = gunController.transform.position;
-        gunPrevForward = -gunController.transform.TransformDirection(Vector3.forward);
+        if(!IsAngleChangeWithinBounds(changeInXRotation))
+        {
+            gunPrevPosition = gunController.transform.position;
+            gunPrevForward = -gunController.transform.TransformDirection(Vector3.forward);
+        }
     }
 
 
     private void CheckAndTriggerGunShot()
     {
         float usingChange = changeInXRotation;
-
+        Vector3 usingPosition = gunPrevPosition;
+        Vector3 usingForward = gunPrevForward;
         if (framesSinceLastShot == -1 && IsAngleChangeWithinBounds(usingChange))
         {
 
-            gunController.ShootGun(gunPrevPosition, gunPrevForward);
+            gunController.ShootGun(usingPosition, usingForward);
             framesSinceLastShot = 0;
         }
 

--- a/Assets/Scripts/AngleBasedShootTrigger.cs
+++ b/Assets/Scripts/AngleBasedShootTrigger.cs
@@ -1,0 +1,75 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class AngleBasedShootTrigger : MonoBehaviour
+{
+    [Header("Rotations")]
+    public float updatePreviousPositionInterval = 0.5f;
+    public float previousXRotation;
+    public float currentXRotation;
+    public float changeInXRotation;
+
+    [Header("Gun settings")]
+    public GunController gunController;
+    public float minChangeToShootGun = 25f;
+    public float maxChangeToShoot = 90f;
+    public int inFramesBetweenShot = 30;
+    public int framesSinceLastShot = -1;
+
+
+    private Vector3 gunPrevPosition;
+    private Vector3 gunPrevForward;
+    // Start is called before the first frame update
+    void Start()
+    { 
+        InvokeRepeating("UpdatePreviousForwardPosition", 0f, updatePreviousPositionInterval);
+    }
+
+    // Update is called once per frame
+    void FixedUpdate()
+    {
+        currentXRotation = transform.localEulerAngles.x;
+        changeInXRotation = previousXRotation - currentXRotation;
+
+        CheckAndTriggerGunShot();
+         
+        previousXRotation = transform.localEulerAngles.x;
+    }
+
+    void UpdatePreviousForwardPosition()
+    {
+        gunPrevPosition = gunController.transform.position;
+        gunPrevForward = -gunController.transform.TransformDirection(Vector3.forward);
+    }
+
+
+    private void CheckAndTriggerGunShot()
+    {
+        float usingChange = changeInXRotation;
+
+        if (framesSinceLastShot == -1 && IsAngleChangeWithinBounds(usingChange))
+        {
+
+            gunController.ShootGun(gunPrevPosition, gunPrevForward);
+            framesSinceLastShot = 0;
+        }
+
+        if (framesSinceLastShot > inFramesBetweenShot)
+        {
+            framesSinceLastShot = -1;
+            UpdatePreviousForwardPosition();
+        }
+        else if (framesSinceLastShot != -1)
+        {
+            framesSinceLastShot++;
+        }
+
+    }
+
+    private bool IsAngleChangeWithinBounds(float angleChange)
+    {
+        return minChangeToShootGun < angleChange && angleChange < maxChangeToShoot;
+    }
+
+}

--- a/Assets/Scripts/AngleBasedShootTrigger.cs.meta
+++ b/Assets/Scripts/AngleBasedShootTrigger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4672db08c1e9ae47b8c15ffcb1ad013
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GunController.cs
+++ b/Assets/Scripts/GunController.cs
@@ -21,12 +21,16 @@ public class GunController : MonoBehaviour
     }
 
 
-    public RaycastHit ShootGun()
+    public RaycastHit ShootGun(
+        Vector3? position = null,
+        Vector3? forward = null
+    )
     {
         scoreController.IncrementNumberOfShots();
 
-        Vector3 fwd = -transform.TransformDirection(Vector3.forward);
-        RaycastHit hit;
+        Vector3 useForward = forward ?? -transform.TransformDirection(Vector3.forward);
+        Vector3 usePosition = position ?? transform.position;
+        /*RaycastHit hit;
 
         Debug.DrawRay(transform.position, fwd * maxLineLength, Color.red);
         if (Physics.Raycast(transform.position, fwd, out hit, maxLineLength, layerMask)) {
@@ -35,6 +39,31 @@ public class GunController : MonoBehaviour
                 scoreController.AddToScore(1);
                 mainParticleModule.startColor = hitColor;
             } else
+            {
+                mainParticleModule.startColor = missColor;
+            }
+            Instantiate(hitParticle, hit.point, Quaternion.identity);
+        }
+
+
+        return hit;*/
+
+        return ShootRay(usePosition, useForward);
+    }
+
+
+    private RaycastHit ShootRay(Vector3 position, Vector3 forward)
+    {
+        RaycastHit hit;
+        Debug.DrawRay(position, forward * maxLineLength, Color.red);
+        if (Physics.Raycast(position, forward, out hit, maxLineLength, layerMask))
+        {
+            if (hit.collider.gameObject.CompareTag("Target"))
+            {
+                scoreController.AddToScore(1);
+                mainParticleModule.startColor = hitColor;
+            }
+            else
             {
                 mainParticleModule.startColor = missColor;
             }


### PR DESCRIPTION
- adds a rotation trigger in order to shoot the gun. 

Room for improvement:

around 1-2 out of every 10 shots misfires upwards due to the updating of the forward direction.  Can potentially update this to update more frequently in specific angle range and then only if not invoke a repeating function

Issue: #18